### PR TITLE
fix: jaendata fetching in production

### DIFF
--- a/src/core/common/utils.ts
+++ b/src/core/common/utils.ts
@@ -9,7 +9,6 @@
  */
 import deepmerge from 'deepmerge'
 import _ from 'lodash'
-import process from 'process'
 
 export type AtLeastOne<T, U = {[K in keyof T]: Pick<T, K>}> = Partial<T> &
   U[keyof U]
@@ -17,11 +16,7 @@ export type AtLeastOne<T, U = {[K in keyof T]: Pick<T, K>}> = Partial<T> &
 export type RecursivePartial<T> = {
   [P in keyof T]?: RecursivePartial<T[P]>
 }
-
-const development: boolean =
-  !process.env.NODE_ENV || process.env.NODE_ENV === 'development'
-
-export const isDev = () => development
+export const isDevelopment = process.env.NODE_ENV !== 'production'
 
 export const deepSearch = (object: any, key: any, predicate: any) => {
   const search = (object: any, key: any, predicate: any): any => {

--- a/src/core/store/actions/cms.ts
+++ b/src/core/store/actions/cms.ts
@@ -14,7 +14,7 @@ import gzip from 'gzip-js'
 import {PageParamsType, components} from '~/types'
 
 import {encrypt} from '~/common/crypt'
-import {blobToFile, isDev} from '~/common/utils'
+import {blobToFile, isDevelopment} from '~/common/utils'
 
 import {BlockFieldOptions} from '~/components/blocks'
 
@@ -147,7 +147,7 @@ export const fetchJaenData = createAsyncThunk<void, void, {}>(
 
       // Do not fetch if state.cms.settings.gitRemote is not undefined in dev mode
       // this leads to a onetime load in development and (n) laods in deployment
-      if (!(isDev() && state.cms.settings.gitRemote)) {
+      if (!(isDevelopment && state.cms.settings.gitRemote)) {
         fetchFile(`${globalThis.location.origin}/jaen-data.json`)
       }
     } catch (err) {


### PR DESCRIPTION
Changes the production dedection to allow periodic jaendata fetching
in production but not in development.
Previously the process module was imported in `utils.ts` which resulted
in incorrect determination of the production status.